### PR TITLE
add rejection reason confirmation in superintendent view

### DIFF
--- a/backend/proj_backend/api/views.py
+++ b/backend/proj_backend/api/views.py
@@ -393,7 +393,7 @@ def check_pending_requests(request):
     pending_requests = RequestManagement.objects.filter(
         user=request.user,
         # Add all statuses you want to include
-        status__in=['pending', 'rejected', 'pending', 'approved']
+        status__in=['pending', 'pending', 'approved']
     ).order_by('-created_at')
 
     # Check for liquidations that aren't completed

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -150,12 +150,12 @@ export type ButtonProps = React.ComponentPropsWithoutRef<"button"> & {
   children: React.ReactNode; // Button text or content
   size?: "sm" | "md"; // Button size
   variant?:
-    | "primary"
-    | "outline"
-    | "error"
-    | "success"
-    | "destructive"
-    | "ghost"; // Button variant
+  | "primary"
+  | "outline"
+  | "error"
+  | "success"
+  | "destructive"
+  | "ghost"; // Button variant
   loading?: boolean;
   startIcon?: React.ReactNode; // Icon before the text
   endIcon?: React.ReactNode; // Icon after the text
@@ -188,6 +188,7 @@ export type Submission = {
   priorities: Priority[];
   status: "pending" | "approved" | "rejected" | "unliquidated";
   created_at: string;
+  rejection_reason?: string; // Optional field for rejection reason
 };
 
 type Priority = {

--- a/frontend/src/pages/PriortySubmissionsPage.tsx
+++ b/frontend/src/pages/PriortySubmissionsPage.tsx
@@ -32,6 +32,7 @@ const PriortySubmissionsPage = () => {
   const [viewedSubmission, setViewedSubmission] = useState<Submission | null>(
     null
   );
+  const [rejectionReason, setRejectionReason] = useState("");
   const [submissionsState, setSubmissionsState] = useState<Submission[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -101,24 +102,32 @@ const PriortySubmissionsPage = () => {
   // Reject handler (should call backend in real app)
   const handleRejectClick = (submission: Submission) => {
     setSubmissionToReject(submission);
+    setRejectionReason(""); // Clear any previous reason
     setIsRejectDialogOpen(true);
   };
-  const handleReject = async (submission: Submission) => {
+  const handleReject = async (submission: Submission, reason: string) => {
     try {
       await api.put(`requests/${submission.request_id}/`, {
         status: "rejected",
+        rejection_reason: reason, // Include the rejection reason
       });
-      setViewedSubmission(null); // Close the modal
+      setViewedSubmission(null);
       setSubmissionsState((prev) =>
         prev.map((s) =>
           s.request_id === submission.request_id
-            ? { ...s, status: "rejected" }
+            ? { ...s, status: "rejected", rejection_reason: reason }
             : s
         )
       );
-      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      toast.success(`Request #${submission.request_id} has been rejected.`, {
+        autoClose: 5000,
+        position: "top-right",
+        icon: <XCircle className="w-6 h-6" />,
+      });
+      await fetchSubmissions(); // Refresh the list after rejection
     } catch (err) {
       console.error("Failed to reject submission:", err);
+      toast.error("Failed to reject submission. Please try again.");
     }
   };
 
@@ -509,6 +518,18 @@ const PriortySubmissionsPage = () => {
                 </div>
               </div>
 
+              {/* Add this block right here */}
+              {viewedSubmission?.status === "rejected" &&
+                viewedSubmission.rejection_reason && (
+                  <div className="mt-4 p-4 bg-red-50 dark:bg-red-900/20 rounded-lg border border-red-100 dark:border-red-900/30">
+                    <h4 className="font-medium text-red-800 dark:text-red-200">
+                      Rejection Reason:
+                    </h4>
+                    <p className="text-red-700 dark:text-red-300 mt-1">
+                      {viewedSubmission.rejection_reason}
+                    </p>
+                  </div>
+                )}
               {/* Action Buttons */}
               <div className="flex flex-col sm:flex-row justify-end gap-3 pt-4 border-t border-gray-200 dark:border-gray-700">
                 <Button
@@ -553,6 +574,7 @@ const PriortySubmissionsPage = () => {
         </DialogContent>
       </Dialog>
       {/* Reject Confirmation Dialog */}
+      {/* Reject Confirmation Dialog */}
       <Dialog open={isRejectDialogOpen} onOpenChange={setIsRejectDialogOpen}>
         <DialogContent className="w-full rounded-lg bg-white dark:bg-gray-800 p-6 shadow-xl">
           <DialogHeader className="mb-6">
@@ -570,6 +592,89 @@ const PriortySubmissionsPage = () => {
                 </strong>
                 ? This action cannot be undone.
               </p>
+
+              {/* Add rejection reason textarea */}
+              <div className="space-y-2">
+                <label
+                  htmlFor="rejectionReason"
+                  className="block text-sm font-medium text-gray-700 dark:text-gray-300"
+                >
+                  Reason for rejection (required)
+                </label>
+                <textarea
+                  id="rejectionReason"
+                  rows={3}
+                  className="block w-full rounded-md border-gray-300 shadow-sm focus:border-brand-500 focus:ring-brand-500 sm:text-sm dark:bg-gray-700 dark:border-gray-600 dark:text-white"
+                  placeholder="Enter the reason for rejection..."
+                  value={rejectionReason}
+                  onChange={(e) => setRejectionReason(e.target.value)}
+                  required
+                />
+              </div>
+
+              <div className="flex justify-end gap-3 pt-4">
+                <Button
+                  type="button"
+                  variant="outline"
+                  onClick={() => {
+                    setIsRejectDialogOpen(false);
+                    setRejectionReason(""); // Clear reason on cancel
+                    setSubmissionToReject(null);
+                  }}
+                >
+                  Cancel
+                </Button>
+                <Button
+                  type="button"
+                  variant="destructive"
+                  disabled={!rejectionReason.trim()} // Disable if no reason provided
+                  onClick={() => {
+                    handleReject(submissionToReject, rejectionReason);
+                    setIsRejectDialogOpen(false);
+                    setRejectionReason(""); // Clear reason after submission
+                  }}
+                >
+                  Confirm Reject
+                </Button>
+              </div>
+            </div>
+          )}
+        </DialogContent>
+      </Dialog>
+
+      {/* Reject Reason Dialog */}
+      <Dialog open={isRejectDialogOpen} onOpenChange={setIsRejectDialogOpen}>
+        <DialogContent className="w-full rounded-lg bg-white dark:bg-gray-800 p-6 shadow-xl">
+          <DialogHeader className="mb-6">
+            <DialogTitle className="text-2xl font-bold text-gray-800 dark:text-white">
+              Reject Submission
+            </DialogTitle>
+          </DialogHeader>
+          {submissionToReject && (
+            <div className="space-y-4">
+              <p className="text-gray-600 dark:text-gray-400">
+                Are you sure you want to reject the submission from{" "}
+                <strong>
+                  {submissionToReject.user.first_name}{" "}
+                  {submissionToReject.user.last_name}
+                </strong>
+                ? This action cannot be undone.
+              </p>
+              <div className="flex flex-col">
+                <label
+                  htmlFor="rejection-reason"
+                  className="mb-2 text-sm font-medium text-gray-700 dark:text-gray-300"
+                >
+                  Reason for Rejection
+                </label>
+                <textarea
+                  id="rejection-reason"
+                  value={rejectionReason}
+                  onChange={(e) => setRejectionReason(e.target.value)}
+                  className="border border-gray-300 dark:border-gray-700 rounded-lg p-2"
+                  rows={4}
+                />
+              </div>
               <div className="flex justify-end gap-3 pt-4">
                 <Button
                   type="button"
@@ -585,7 +690,7 @@ const PriortySubmissionsPage = () => {
                   type="button"
                   variant="destructive"
                   onClick={() => {
-                    handleReject(submissionToReject);
+                    handleReject(submissionToReject, rejectionReason);
                     setIsRejectDialogOpen(false);
                   }}
                 >


### PR DESCRIPTION
## Summary by Sourcery

Enable entering, storing, and displaying a rejection reason in the superintendent’s submission review view, update API and types accordingly, and correct backend request filtering.

New Features:
- Prompt the user to provide a rejection reason in the reject confirmation dialog and send it with the API request
- Display the stored rejection reason in the submission detail modal when viewing a rejected request

Bug Fixes:
- Fix the backend pending requests filter to remove duplicates and exclude rejected status

Enhancements:
- Add an optional rejection_reason field to the Submission type on the frontend
- Refresh the submissions list and show success/error toasts after a reject action