### PR TITLE
Fix backup errors in views.py

### DIFF
--- a/backend/proj_backend/api/views.py
+++ b/backend/proj_backend/api/views.py
@@ -14,6 +14,7 @@ import tempfile
 import shutil
 import os
 import random
+import json
 from django.db.models import Sum
 from django.utils.timezone import localtime
 from openpyxl.styles import Font, Alignment
@@ -30,6 +31,7 @@ from rest_framework.pagination import PageNumberPagination
 from django.db import transaction
 import logging
 from rest_framework import serializers
+from django.core import serializers as django_serializers
 from rest_framework.permissions import IsAuthenticated, AllowAny
 from rest_framework_simplejwt.views import TokenObtainPairView, TokenRefreshView
 from rest_framework_simplejwt.tokens import RefreshToken
@@ -3025,7 +3027,7 @@ def initiate_backup(request):
             for model, model_name in MODEL_BACKUP_ORDER:
                 try:
                     # Use natural keys if available for better serialization
-                    data = serializers.serialize(
+                    data = django_serializers.serialize(
                         "json",
                         model.objects.all(),
                         use_natural_foreign_keys=True,
@@ -3190,7 +3192,7 @@ def initiate_restore(request):
 
                     # Use Django's deserializer
                     objects = []
-                    for obj in serializers.deserialize("json", data):
+                    for obj in django_serializers.deserialize("json", data):
                         try:
                             # Check if object already exists
                             if model.objects.filter(pk=obj.object.pk).exists():


### PR DESCRIPTION
Fix backup/restore by using `django.core.serializers` and importing the missing `json` module.

The previous implementation incorrectly used `rest_framework.serializers` for `serialize` and `deserialize` functions, which are found in `django.core.serializers`. Additionally, the `json` module was missing, causing a `NameError` during the backup process.

---
<a href="https://cursor.com/background-agent?bcId=bc-a0f92212-0be2-44c4-9cf9-915813c9ce40"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-a0f92212-0be2-44c4-9cf9-915813c9ce40"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

## Summary by Sourcery

Fix backup and restore operations by switching to the appropriate Django serializers and adding the missing json import to prevent runtime errors.

Bug Fixes:
- Use django.core.serializers.serialize/deserialize instead of rest_framework.serializers for backup and restore
- Import the json module to avoid NameError during backup